### PR TITLE
fix: align whisper transcriber api with parakeet

### DIFF
--- a/server/docs/gpu/api-transcription.md
+++ b/server/docs/gpu/api-transcription.md
@@ -1,0 +1,178 @@
+## Reflector GPU Transcription API (Parakeet)
+
+This document describes the GPU transcription API deployed on Modal.com using NVIDIA Parakeet. The API surface and response shapes are OpenAI/Whisper-compatible. If desired, you can switch to a Whisper deployment by changing the base URL; no client changes are required.
+
+### Base URL and Authentication
+
+- Parakeet base URL (Modal web endpoint), for example:
+
+  - `https://<account>--reflector-transcriber-parakeet-web.modal.run`
+
+- All endpoints are served under `/v1` and require a Bearer token:
+
+```
+Authorization: Bearer <REFLECTOR_GPU_APIKEY>
+```
+
+Note: To use Whisper instead, deploy the Whisper variant and point `TRANSCRIPT_URL` to its base URL (e.g., `https://<account>--reflector-transcriber-web.modal.run`). The API is identical.
+
+### Supported file types
+
+`mp3, mp4, mpeg, mpga, m4a, wav, webm`
+
+### Models and languages
+
+- Parakeet (NVIDIA NeMo): default `nvidia/parakeet-tdt-0.6b-v2`
+  - Language: only `en` is supported. Other languages return HTTP 400.
+
+Note: The `model` parameter is accepted for interface parity, but is currently informational for Parakeet.
+
+### Endpoints
+
+#### POST /v1/audio/transcriptions
+
+Transcribe one or more uploaded audio files.
+
+Request: multipart/form-data
+
+- `file`: single file to transcribe
+- `files`: multiple files to transcribe
+- `model`: optional, defaults to implementation-specific model (see above)
+- `language`: language code; Parakeet requires `en`
+- `batch`: boolean; when `true` and multiple files are provided, returns a `results` array
+
+Responses
+
+Single file response:
+
+```json
+{
+  "text": "transcribed text",
+  "words": [
+    { "word": "hello", "start": 0.0, "end": 0.5 },
+    { "word": "world", "start": 0.5, "end": 1.0 }
+  ],
+  "filename": "audio.mp3"
+}
+```
+
+Multiple files, non-batch mode (processed one-by-one):
+
+```json
+{
+  "results": [
+    {"filename": "a1.mp3", "text": "...", "words": [...]},
+    {"filename": "a2.mp3", "text": "...", "words": [...]}]
+}
+```
+
+Multiple files with `batch=true`:
+
+```json
+{
+  "results": [
+    {"filename": "a1.mp3", "text": "...", "words": [...]},
+    {"filename": "a2.mp3", "text": "...", "words": [...]}]
+}
+```
+
+Notes:
+
+- Word objects always include keys: `word`, `start`, `end`.
+- Parakeet may include a trailing space in `word` to match Whisper tokenization behavior; clients should trim if needed.
+
+Example curl (single file):
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $REFLECTOR_GPU_APIKEY" \
+  -F "file=@/path/to/audio.mp3" \
+  -F "model=nvidia/parakeet-tdt-0.6b-v2" \
+  -F "language=en" \
+  "$BASE_URL/v1/audio/transcriptions"
+```
+
+Example curl (multiple files, batch):
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $REFLECTOR_GPU_APIKEY" \
+  -F "files=@/path/a1.mp3" -F "files=@/path/a2.mp3" \
+  -F "batch=true" -F "language=en" \
+  "$BASE_URL/v1/audio/transcriptions"
+```
+
+#### POST /v1/audio/transcriptions-from-url
+
+Transcribe a single remote audio file by URL.
+
+Request: application/json
+
+```json
+{
+  "audio_file_url": "https://example.com/audio.mp3",
+  "model": "nvidia/parakeet-tdt-0.6b-v2",
+  "language": "en",
+  "timestamp_offset": 0.0
+}
+```
+
+Response:
+
+```json
+{
+  "text": "transcribed text",
+  "words": [
+    { "word": "hello", "start": 10.0, "end": 10.5 },
+    { "word": "world", "start": 10.5, "end": 11.0 }
+  ]
+}
+```
+
+Notes:
+
+- `timestamp_offset` is added to each word’s `start`/`end` in the response.
+- Parakeet performs VAD-based chunking for long-form audio.
+
+Example curl:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $REFLECTOR_GPU_APIKEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "audio_file_url": "https://example.com/audio.mp3",
+        "language": "en",
+        "timestamp_offset": 0
+      }' \
+  "$BASE_URL/v1/audio/transcriptions-from-url"
+```
+
+### Error handling
+
+- 400 Bad Request
+  - `language` other than `en`
+  - Missing required parameters (`file`/`files` for upload; `audio_file_url` for URL endpoint)
+  - Unsupported file extension
+- 401 Unauthorized
+  - Missing or invalid Bearer token
+- 404 Not Found
+  - `audio_file_url` does not exist
+
+### Implementation details
+
+- GPUs: A10G for small-file/live, L40S for large-file URL transcription
+- VAD chunking and segment batching; word timings adjusted and overlapping ends constrained
+- Pads very short segments (< 0.5s) to avoid model crashes
+
+### Server configuration (Reflector API)
+
+Set the Reflector server to use the Modal backend and point `TRANSCRIPT_URL` to your Parakeet deployment:
+
+```
+TRANSCRIPT_BACKEND=modal
+TRANSCRIPT_URL=https://<account>--reflector-transcriber-parakeet-web.modal.run
+TRANSCRIPT_MODAL_API_KEY=<REFLECTOR_GPU_APIKEY>
+```
+
+To switch to Whisper, simply update `TRANSCRIPT_URL` to the Whisper deployment (e.g., `https://<account>--reflector-transcriber-web.modal.run`). The server integrates via an OpenAI-compatible client, expecting `text` and `words[{word,start,end}]` and supporting both single and multi-file responses per the shapes above.

--- a/server/gpu/modal_deployments/reflector_transcriber.py
+++ b/server/gpu/modal_deployments/reflector_transcriber.py
@@ -1,42 +1,78 @@
 import os
-import tempfile
+import sys
 import threading
+import uuid
+from typing import Generator, Mapping, NamedTuple, NewType, TypedDict
+from urllib.parse import urlparse
 
 import modal
-
-MODELS_DIR = "/models"
 
 MODEL_NAME = "large-v2"
 MODEL_COMPUTE_TYPE: str = "float16"
 MODEL_NUM_WORKERS: int = 1
-
 MINUTES = 60  # seconds
+SAMPLERATE = 16000
+UPLOADS_PATH = "/uploads"
+CACHE_PATH = "/models"
+SUPPORTED_FILE_EXTENSIONS = ["mp3", "mp4", "mpeg", "mpga", "m4a", "wav", "webm"]
+VAD_CONFIG = {
+    "batch_max_duration": 30.0,
+    "silence_padding": 0.5,
+    "window_size": 512,
+}
 
-volume = modal.Volume.from_name("models", create_if_missing=True)
+
+WhisperUniqFilename = NewType("WhisperUniqFilename", str)
+AudioFileExtension = NewType("AudioFileExtension", str)
 
 app = modal.App("reflector-transcriber")
+
+model_cache = modal.Volume.from_name("models", create_if_missing=True)
+upload_volume = modal.Volume.from_name("whisper-uploads", create_if_missing=True)
+
+
+class TimeSegment(NamedTuple):
+    """Represents a time segment with start and end times."""
+
+    start: float
+    end: float
+
+
+class AudioSegment(NamedTuple):
+    """Represents an audio segment with timing and audio data."""
+
+    start: float
+    end: float
+    audio: any
+
+
+class TranscriptResult(NamedTuple):
+    """Represents a transcription result with text and word timings."""
+
+    text: str
+    words: list["WordTiming"]
+
+
+class WordTiming(TypedDict):
+    """Represents a word with its timing information."""
+
+    word: str
+    start: float
+    end: float
 
 
 def download_model():
     from faster_whisper import download_model
 
-    volume.reload()
+    model_cache.reload()
 
-    download_model(MODEL_NAME, cache_dir=MODELS_DIR)
+    download_model(MODEL_NAME, cache_dir=CACHE_PATH)
 
-    volume.commit()
+    model_cache.commit()
 
 
 image = (
     modal.Image.debian_slim(python_version="3.12")
-    .pip_install(
-        "huggingface_hub==0.27.1",
-        "hf-transfer==0.1.9",
-        "torch==2.5.1",
-        "faster-whisper==1.1.1",
-        "fastapi==0.115.12",
-        "requests",
-    )
     .env(
         {
             "HF_HUB_ENABLE_HF_TRANSFER": "1",
@@ -46,8 +82,82 @@ image = (
             ),
         }
     )
-    .run_function(download_model, volumes={MODELS_DIR: volume})
+    .apt_install("ffmpeg")
+    .pip_install(
+        "huggingface_hub==0.27.1",
+        "hf-transfer==0.1.9",
+        "torch==2.5.1",
+        "faster-whisper==1.1.1",
+        "fastapi==0.115.12",
+        "requests",
+        "librosa==0.10.1",
+        "numpy<2",
+        "silero-vad==5.1.0",
+    )
+    .run_function(download_model, volumes={CACHE_PATH: model_cache})
 )
+
+
+def detect_audio_format(url: str, headers: Mapping[str, str]) -> AudioFileExtension:
+    parsed_url = urlparse(url)
+    url_path = parsed_url.path
+
+    for ext in SUPPORTED_FILE_EXTENSIONS:
+        if url_path.lower().endswith(f".{ext}"):
+            return AudioFileExtension(ext)
+
+    content_type = headers.get("content-type", "").lower()
+    if "audio/mpeg" in content_type or "audio/mp3" in content_type:
+        return AudioFileExtension("mp3")
+    if "audio/wav" in content_type:
+        return AudioFileExtension("wav")
+    if "audio/mp4" in content_type:
+        return AudioFileExtension("mp4")
+
+    raise ValueError(
+        f"Unsupported audio format for URL: {url}. "
+        f"Supported extensions: {', '.join(SUPPORTED_FILE_EXTENSIONS)}"
+    )
+
+
+def download_audio_to_volume(
+    audio_file_url: str,
+) -> tuple[WhisperUniqFilename, AudioFileExtension]:
+    import requests
+    from fastapi import HTTPException
+
+    response = requests.head(audio_file_url, allow_redirects=True)
+    if response.status_code == 404:
+        raise HTTPException(status_code=404, detail="Audio file not found")
+
+    response = requests.get(audio_file_url, allow_redirects=True)
+    response.raise_for_status()
+
+    audio_suffix = detect_audio_format(audio_file_url, response.headers)
+    unique_filename = WhisperUniqFilename(f"{uuid.uuid4()}.{audio_suffix}")
+    file_path = f"{UPLOADS_PATH}/{unique_filename}"
+
+    with open(file_path, "wb") as f:
+        f.write(response.content)
+
+    upload_volume.commit()
+    return unique_filename, audio_suffix
+
+
+def pad_audio(audio_array, sample_rate: int = SAMPLERATE):
+    """Add 0.5s of silence if audio is shorter than the silence_padding window.
+
+    Whisper does not require this strictly, but aligning behavior with Parakeet
+    avoids edge-case crashes on extremely short inputs and makes comparisons easier.
+    """
+    import numpy as np
+
+    audio_duration = len(audio_array) / sample_rate
+    if audio_duration < VAD_CONFIG["silence_padding"]:
+        silence_samples = int(sample_rate * VAD_CONFIG["silence_padding"])
+        silence = np.zeros(silence_samples, dtype=np.float32)
+        return np.concatenate([audio_array, silence])
+    return audio_array
 
 
 @app.cls(
@@ -55,10 +165,15 @@ image = (
     timeout=5 * MINUTES,
     scaledown_window=5 * MINUTES,
     image=image,
-    volumes={MODELS_DIR: volume},
+    volumes={CACHE_PATH: model_cache, UPLOADS_PATH: upload_volume},
 )
-@modal.concurrent(max_inputs=6)
-class Transcriber:
+@modal.concurrent(max_inputs=10)
+class TranscriberWhisperLive:
+    """Live transcriber class for small audio segments (A10G).
+
+    Mirrors the Parakeet live class API but uses Faster-Whisper under the hood.
+    """
+
     @modal.enter()
     def enter(self):
         import faster_whisper
@@ -72,23 +187,200 @@ class Transcriber:
             device=self.device,
             compute_type=MODEL_COMPUTE_TYPE,
             num_workers=MODEL_NUM_WORKERS,
-            download_root=MODELS_DIR,
+            download_root=CACHE_PATH,
             local_files_only=True,
         )
+        print(f"Model is on device: {self.device}")
 
     @modal.method()
     def transcribe_segment(
         self,
-        audio_data: bytes,
-        audio_suffix: str,
-        language: str,
+        filename: str,
+        language: str = "en",
     ):
-        with tempfile.NamedTemporaryFile("wb+", suffix=f".{audio_suffix}") as fp:
-            fp.write(audio_data)
+        """Transcribe a single uploaded audio file by filename."""
+        upload_volume.reload()
+
+        file_path = f"{UPLOADS_PATH}/{filename}"
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"File not found: {file_path}")
+
+        with self.lock:
+            with NoStdStreams():
+                segments, _ = self.model.transcribe(
+                    file_path,
+                    language=language,
+                    beam_size=5,
+                    word_timestamps=True,
+                    vad_filter=True,
+                    vad_parameters={"min_silence_duration_ms": 500},
+                )
+
+        segments = list(segments)
+        text = "".join(segment.text for segment in segments).strip()
+        words = [
+            {
+                "word": word.word,
+                "start": round(float(word.start), 2),
+                "end": round(float(word.end), 2),
+            }
+            for segment in segments
+            for word in segment.words
+        ]
+
+        return {"text": text, "words": words}
+
+    @modal.method()
+    def transcribe_batch(
+        self,
+        filenames: list[str],
+        language: str = "en",
+    ):
+        """Transcribe multiple uploaded audio files and return per-file results."""
+        upload_volume.reload()
+
+        results = []
+        for filename in filenames:
+            file_path = f"{UPLOADS_PATH}/{filename}"
+            if not os.path.exists(file_path):
+                raise FileNotFoundError(f"Batch file not found: {file_path}")
+
+            with self.lock:
+                with NoStdStreams():
+                    segments, _ = self.model.transcribe(
+                        file_path,
+                        language=language,
+                        beam_size=5,
+                        word_timestamps=True,
+                        vad_filter=True,
+                        vad_parameters={"min_silence_duration_ms": 500},
+                    )
+
+            segments = list(segments)
+            text = "".join(seg.text for seg in segments).strip()
+            words = [
+                {
+                    "word": w.word,
+                    "start": round(float(w.start), 2),
+                    "end": round(float(w.end), 2),
+                }
+                for seg in segments
+                for w in seg.words
+            ]
+
+            results.append(
+                {
+                    "filename": filename,
+                    "text": text,
+                    "words": words,
+                }
+            )
+
+        return results
+
+
+@app.cls(
+    gpu="L40S",
+    timeout=15 * MINUTES,
+    image=image,
+    volumes={CACHE_PATH: model_cache, UPLOADS_PATH: upload_volume},
+)
+class TranscriberWhisperFile:
+    """File transcriber for larger/longer audio, using VAD-driven batching (L40S)."""
+
+    @modal.enter()
+    def enter(self):
+        import faster_whisper
+        import torch
+        from silero_vad import load_silero_vad
+
+        self.lock = threading.Lock()
+        self.use_gpu = torch.cuda.is_available()
+        self.device = "cuda" if self.use_gpu else "cpu"
+        self.model = faster_whisper.WhisperModel(
+            MODEL_NAME,
+            device=self.device,
+            compute_type=MODEL_COMPUTE_TYPE,
+            num_workers=MODEL_NUM_WORKERS,
+            download_root=CACHE_PATH,
+            local_files_only=True,
+        )
+        self.vad_model = load_silero_vad(onnx=False)
+
+    @modal.method()
+    def transcribe_segment(
+        self, filename: str, timestamp_offset: float = 0.0, language: str = "en"
+    ):
+        import librosa
+        import numpy as np
+        from silero_vad import VADIterator
+
+        def vad_segments(
+            audio_array,
+            sample_rate: int = SAMPLERATE,
+            window_size: int = VAD_CONFIG["window_size"],
+        ) -> Generator[TimeSegment, None, None]:
+            """Generate speech segments as TimeSegment using Silero VAD."""
+            iterator = VADIterator(self.vad_model, sampling_rate=sample_rate)
+            start = None
+            for i in range(0, len(audio_array), window_size):
+                chunk = audio_array[i : i + window_size]
+                if len(chunk) < window_size:
+                    chunk = np.pad(
+                        chunk, (0, window_size - len(chunk)), mode="constant"
+                    )
+                speech = iterator(chunk)
+                if not speech:
+                    continue
+                if "start" in speech:
+                    start = speech["start"]
+                    continue
+                if "end" in speech and start is not None:
+                    end = speech["end"]
+                    yield TimeSegment(
+                        start / float(SAMPLERATE), end / float(SAMPLERATE)
+                    )
+                    start = None
+            iterator.reset_states()
+
+        upload_volume.reload()
+        file_path = f"{UPLOADS_PATH}/{filename}"
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"File not found: {file_path}")
+
+        audio_array, _sr = librosa.load(file_path, sr=SAMPLERATE, mono=True)
+
+        # Batch segments up to ~30s windows by merging contiguous VAD segments
+        merged_batches: list[TimeSegment] = []
+        batch_start = None
+        batch_end = None
+        max_duration = VAD_CONFIG["batch_max_duration"]
+        for segment in vad_segments(audio_array):
+            seg_start, seg_end = segment.start, segment.end
+            if batch_start is None:
+                batch_start, batch_end = seg_start, seg_end
+                continue
+            if seg_end - batch_start <= max_duration:
+                batch_end = seg_end
+            else:
+                merged_batches.append(TimeSegment(batch_start, batch_end))
+                batch_start, batch_end = seg_start, seg_end
+        if batch_start is not None and batch_end is not None:
+            merged_batches.append(TimeSegment(batch_start, batch_end))
+
+        all_text = []
+        all_words = []
+
+        for segment in merged_batches:
+            start_time, end_time = segment.start, segment.end
+            s_idx = int(start_time * SAMPLERATE)
+            e_idx = int(end_time * SAMPLERATE)
+            segment = audio_array[s_idx:e_idx]
+            segment = pad_audio(segment, SAMPLERATE)
 
             with self.lock:
                 segments, _ = self.model.transcribe(
-                    fp.name,
+                    segment,
                     language=language,
                     beam_size=5,
                     word_timestamps=True,
@@ -97,30 +389,83 @@ class Transcriber:
                 )
 
             segments = list(segments)
-            text = "".join(segment.text for segment in segments)
+            text = "".join(seg.text for seg in segments).strip()
             words = [
-                {"word": word.word, "start": word.start, "end": word.end}
-                for segment in segments
-                for word in segment.words
+                {
+                    "word": w.word,
+                    "start": round(float(w.start) + start_time + timestamp_offset, 2),
+                    "end": round(float(w.end) + start_time + timestamp_offset, 2),
+                }
+                for seg in segments
+                for w in seg.words
             ]
+            if text:
+                all_text.append(text)
+            all_words.extend(words)
 
-            return {"text": text, "words": words}
+        return {"text": " ".join(all_text), "words": all_words}
+
+
+def detect_audio_format(url: str, headers: dict) -> str:
+    from urllib.parse import urlparse
+
+    from fastapi import HTTPException
+
+    url_path = urlparse(url).path
+    for ext in SUPPORTED_FILE_EXTENSIONS:
+        if url_path.lower().endswith(f".{ext}"):
+            return ext
+
+    content_type = headers.get("content-type", "").lower()
+    if "audio/mpeg" in content_type or "audio/mp3" in content_type:
+        return "mp3"
+    if "audio/wav" in content_type:
+        return "wav"
+    if "audio/mp4" in content_type:
+        return "mp4"
+
+    raise HTTPException(
+        status_code=400,
+        detail=(
+            f"Unsupported audio format for URL. Supported extensions: {', '.join(SUPPORTED_FILE_EXTENSIONS)}"
+        ),
+    )
+
+
+def download_audio_to_volume(audio_file_url: str) -> tuple[str, str]:
+    import requests
+    from fastapi import HTTPException
+
+    response = requests.head(audio_file_url, allow_redirects=True)
+    if response.status_code == 404:
+        raise HTTPException(status_code=404, detail="Audio file not found")
+
+    response = requests.get(audio_file_url, allow_redirects=True)
+    response.raise_for_status()
+
+    audio_suffix = detect_audio_format(audio_file_url, response.headers)
+    unique_filename = f"{uuid.uuid4()}.{audio_suffix}"
+    file_path = f"{UPLOADS_PATH}/{unique_filename}"
+
+    with open(file_path, "wb") as f:
+        f.write(response.content)
+
+    upload_volume.commit()
+    return unique_filename, audio_suffix
 
 
 @app.function(
     scaledown_window=60,
-    timeout=60,
+    timeout=600,
     secrets=[
         modal.Secret.from_name("reflector-gpu"),
     ],
-    volumes={MODELS_DIR: volume},
+    volumes={CACHE_PATH: model_cache, UPLOADS_PATH: upload_volume},
     image=image,
 )
 @modal.concurrent(max_inputs=40)
 @modal.asgi_app()
 def web():
-    import uuid
-
     from fastapi import (
         Body,
         Depends,
@@ -132,13 +477,12 @@ def web():
     )
     from fastapi.security import OAuth2PasswordBearer
 
-    transcriber = Transcriber()
+    transcriber_live = TranscriberWhisperLive()
+    transcriber_file = TranscriberWhisperFile()
 
     app = FastAPI()
 
     oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
-
-    supported_file_types = ["mp3", "mp4", "mpeg", "mpga", "m4a", "wav", "webm"]
 
     def apikey_auth(apikey: str = Depends(oauth2_scheme)):
         if apikey == os.environ["REFLECTOR_GPU_APIKEY"]:
@@ -149,32 +493,12 @@ def web():
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    def detect_audio_format(url: str, headers: dict) -> str:
-        from urllib.parse import urlparse
-
-        url_path = urlparse(url).path
-        for ext in supported_file_types:
-            if url_path.lower().endswith(f".{ext}"):
-                return ext
-
-        content_type = headers.get("content-type", "").lower()
-        if "audio/mpeg" in content_type or "audio/mp3" in content_type:
-            return "mp3"
-        if "audio/wav" in content_type:
-            return "wav"
-        if "audio/mp4" in content_type:
-            return "mp4"
-
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"Unsupported audio format for URL. Supported extensions: {', '.join(supported_file_types)}"
-            ),
-        )
+    class TranscriptResponse(dict):
+        pass
 
     @app.post("/v1/audio/transcriptions", dependencies=[Depends(apikey_auth)])
     def transcribe(
-        file: UploadFile | None = None,
+        file: UploadFile = None,
         files: list[UploadFile] | None = None,
         model: str = Form(MODEL_NAME),
         language: str = Form("en"),
@@ -184,31 +508,61 @@ def web():
             raise HTTPException(
                 status_code=400, detail="Either 'file' or 'files' parameter is required"
             )
+        if batch and not files:
+            raise HTTPException(
+                status_code=400, detail="Batch transcription requires 'files'"
+            )
 
         upload_files = [file] if file else files
-        results = []
 
+        uploaded_filenames: list[str] = []
         for upload_file in upload_files:
             audio_suffix = upload_file.filename.split(".")[-1]
-            if audio_suffix not in supported_file_types:
+            if audio_suffix not in SUPPORTED_FILE_EXTENSIONS:
                 raise HTTPException(
                     status_code=400,
                     detail=(
-                        f"Unsupported audio format. Supported extensions: {', '.join(supported_file_types)}"
+                        f"Unsupported audio format. Supported extensions: {', '.join(SUPPORTED_FILE_EXTENSIONS)}"
                     ),
                 )
 
-            content = upload_file.file.read()
-            func = transcriber.transcribe_segment.spawn(
-                audio_data=content,
-                audio_suffix=audio_suffix,
-                language=language,
-            )
-            result = func.get()
-            result["filename"] = upload_file.filename or str(uuid.uuid4())
-            results.append(result)
+            unique_filename = f"{uuid.uuid4()}.{audio_suffix}"
+            file_path = f"{UPLOADS_PATH}/{unique_filename}"
+            with open(file_path, "wb") as f:
+                content = upload_file.file.read()
+                f.write(content)
+            uploaded_filenames.append(unique_filename)
 
-        return {"results": results} if len(results) > 1 else results[0]
+        upload_volume.commit()
+
+        try:
+            if batch and len(upload_files) > 1:
+                func = transcriber_live.transcribe_batch.spawn(
+                    filenames=uploaded_filenames,
+                    language=language,
+                )
+                results = func.get()
+                return {"results": results}
+
+            results = []
+            for filename in uploaded_filenames:
+                func = transcriber_live.transcribe_segment.spawn(
+                    filename=filename,
+                    language=language,
+                )
+                result = func.get()
+                result["filename"] = filename
+                results.append(result)
+
+            return {"results": results} if len(results) > 1 else results[0]
+        finally:
+            for filename in uploaded_filenames:
+                try:
+                    file_path = f"{UPLOADS_PATH}/{filename}"
+                    os.remove(file_path)
+                except Exception:
+                    pass
+            upload_volume.commit()
 
     @app.post("/v1/audio/transcriptions-from-url", dependencies=[Depends(apikey_auth)])
     def transcribe_from_url(
@@ -219,34 +573,36 @@ def web():
         language: str = Body("en"),
         timestamp_offset: float = Body(0.0),
     ):
-        import requests
-
-        head_response = requests.head(audio_file_url, allow_redirects=True)
-        if head_response.status_code == 404:
-            raise HTTPException(status_code=404, detail="Audio file not found")
-
-        response = requests.get(audio_file_url, allow_redirects=True)
-        response.raise_for_status()
-
-        audio_suffix = detect_audio_format(audio_file_url, response.headers)
-        audio_data = response.content
-
-        func = transcriber.transcribe_segment.spawn(
-            audio_data=audio_data,
-            audio_suffix=audio_suffix,
-            language=language,
-        )
-        result = func.get()
-
-        if timestamp_offset:
-            words = result.get("words", [])
-            for w in words:
-                if "start" in w:
-                    w["start"] = round(float(w["start"]) + timestamp_offset, 2)
-                if "end" in w:
-                    w["end"] = round(float(w["end"]) + timestamp_offset, 2)
-            result["words"] = words
-
-        return result
+        unique_filename, _audio_suffix = download_audio_to_volume(audio_file_url)
+        try:
+            func = transcriber_file.transcribe_segment.spawn(
+                filename=unique_filename,
+                timestamp_offset=timestamp_offset,
+                language=language,
+            )
+            result = func.get()
+            return result
+        finally:
+            try:
+                file_path = f"{UPLOADS_PATH}/{unique_filename}"
+                os.remove(file_path)
+                upload_volume.commit()
+            except Exception:
+                pass
 
     return app
+
+
+class NoStdStreams:
+    def __init__(self):
+        self.devnull = open(os.devnull, "w")
+
+    def __enter__(self):
+        self._stdout, self._stderr = sys.stdout, sys.stderr
+        self._stdout.flush()
+        self._stderr.flush()
+        sys.stdout, sys.stderr = self.devnull, self.devnull
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        sys.stdout, sys.stderr = self._stdout, self._stderr
+        self.devnull.close()

--- a/server/gpu/modal_deployments/reflector_transcriber.py
+++ b/server/gpu/modal_deployments/reflector_transcriber.py
@@ -190,7 +190,13 @@ def web():
 
         for upload_file in upload_files:
             audio_suffix = upload_file.filename.split(".")[-1]
-            assert audio_suffix in supported_file_types
+            if audio_suffix not in supported_file_types:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Unsupported audio format. Supported extensions: {', '.join(supported_file_types)}"
+                    ),
+                )
 
             content = upload_file.file.read()
             func = transcriber.transcribe_segment.spawn(

--- a/server/gpu/modal_deployments/reflector_transcriber.py
+++ b/server/gpu/modal_deployments/reflector_transcriber.py
@@ -3,7 +3,6 @@ import tempfile
 import threading
 
 import modal
-from pydantic import BaseModel
 
 MODELS_DIR = "/models"
 
@@ -35,6 +34,8 @@ image = (
         "hf-transfer==0.1.9",
         "torch==2.5.1",
         "faster-whisper==1.1.1",
+        "fastapi==0.115.12",
+        "requests",
     )
     .env(
         {
@@ -53,10 +54,10 @@ image = (
     gpu="A10G",
     timeout=5 * MINUTES,
     scaledown_window=5 * MINUTES,
-    allow_concurrent_inputs=6,
     image=image,
     volumes={MODELS_DIR: volume},
 )
+@modal.concurrent(max_inputs=6)
 class Transcriber:
     @modal.enter()
     def enter(self):
@@ -78,7 +79,7 @@ class Transcriber:
     @modal.method()
     def transcribe_segment(
         self,
-        audio_data: str,
+        audio_data: bytes,
         audio_suffix: str,
         language: str,
     ):
@@ -109,17 +110,27 @@ class Transcriber:
 @app.function(
     scaledown_window=60,
     timeout=60,
-    allow_concurrent_inputs=40,
     secrets=[
         modal.Secret.from_name("reflector-gpu"),
     ],
     volumes={MODELS_DIR: volume},
+    image=image,
 )
+@modal.concurrent(max_inputs=40)
 @modal.asgi_app()
 def web():
-    from fastapi import Body, Depends, FastAPI, HTTPException, UploadFile, status
+    import uuid
+
+    from fastapi import (
+        Body,
+        Depends,
+        FastAPI,
+        Form,
+        HTTPException,
+        UploadFile,
+        status,
+    )
     from fastapi.security import OAuth2PasswordBearer
-    from typing_extensions import Annotated
 
     transcriber = Transcriber()
 
@@ -130,25 +141,89 @@ def web():
     supported_file_types = ["mp3", "mp4", "mpeg", "mpga", "m4a", "wav", "webm"]
 
     def apikey_auth(apikey: str = Depends(oauth2_scheme)):
-        if apikey != os.environ["REFLECTOR_GPU_APIKEY"]:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid API key",
-                headers={"WWW-Authenticate": "Bearer"},
-            )
+        if apikey == os.environ["REFLECTOR_GPU_APIKEY"]:
+            return
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid API key",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
-    class TranscriptResponse(BaseModel):
-        result: dict
+    def detect_audio_format(url: str, headers: dict) -> str:
+        from urllib.parse import urlparse
+
+        url_path = urlparse(url).path
+        for ext in supported_file_types:
+            if url_path.lower().endswith(f".{ext}"):
+                return ext
+
+        content_type = headers.get("content-type", "").lower()
+        if "audio/mpeg" in content_type or "audio/mp3" in content_type:
+            return "mp3"
+        if "audio/wav" in content_type:
+            return "wav"
+        if "audio/mp4" in content_type:
+            return "mp4"
+
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Unsupported audio format for URL. Supported extensions: {', '.join(supported_file_types)}"
+            ),
+        )
 
     @app.post("/v1/audio/transcriptions", dependencies=[Depends(apikey_auth)])
     def transcribe(
-        file: UploadFile,
-        model: str = "whisper-1",
-        language: Annotated[str, Body(...)] = "en",
-    ) -> TranscriptResponse:
-        audio_data = file.file.read()
-        audio_suffix = file.filename.split(".")[-1]
-        assert audio_suffix in supported_file_types
+        file: UploadFile | None = None,
+        files: list[UploadFile] | None = None,
+        model: str = Form(MODEL_NAME),
+        language: str = Form("en"),
+        batch: bool = Form(False),
+    ):
+        if not file and not files:
+            raise HTTPException(
+                status_code=400, detail="Either 'file' or 'files' parameter is required"
+            )
+
+        upload_files = [file] if file else files
+        results = []
+
+        for upload_file in upload_files:
+            audio_suffix = upload_file.filename.split(".")[-1]
+            assert audio_suffix in supported_file_types
+
+            content = upload_file.file.read()
+            func = transcriber.transcribe_segment.spawn(
+                audio_data=content,
+                audio_suffix=audio_suffix,
+                language=language,
+            )
+            result = func.get()
+            result["filename"] = upload_file.filename or str(uuid.uuid4())
+            results.append(result)
+
+        return {"results": results} if len(results) > 1 else results[0]
+
+    @app.post("/v1/audio/transcriptions-from-url", dependencies=[Depends(apikey_auth)])
+    def transcribe_from_url(
+        audio_file_url: str = Body(
+            ..., description="URL of the audio file to transcribe"
+        ),
+        model: str = Body(MODEL_NAME),
+        language: str = Body("en"),
+        timestamp_offset: float = Body(0.0),
+    ):
+        import requests
+
+        head_response = requests.head(audio_file_url, allow_redirects=True)
+        if head_response.status_code == 404:
+            raise HTTPException(status_code=404, detail="Audio file not found")
+
+        response = requests.get(audio_file_url, allow_redirects=True)
+        response.raise_for_status()
+
+        audio_suffix = detect_audio_format(audio_file_url, response.headers)
+        audio_data = response.content
 
         func = transcriber.transcribe_segment.spawn(
             audio_data=audio_data,
@@ -156,6 +231,16 @@ def web():
             language=language,
         )
         result = func.get()
+
+        if timestamp_offset:
+            words = result.get("words", [])
+            for w in words:
+                if "start" in w:
+                    w["start"] = round(float(w["start"]) + timestamp_offset, 2)
+                if "end" in w:
+                    w["end"] = round(float(w["end"]) + timestamp_offset, 2)
+            result["words"] = words
+
         return result
 
     return app

--- a/server/tests/test_gpu_modal_transcript.py
+++ b/server/tests/test_gpu_modal_transcript.py
@@ -272,6 +272,9 @@ class TestGPUModalTranscript:
                 for f in temp_files:
                     Path(f).unlink(missing_ok=True)
 
+    @pytest.mark.skipif(
+        not "parakeet" in get_model_name(), reason="Parakeet only supports English"
+    )
     def test_transcriptions_error_handling(self):
         """Test error handling for invalid requests."""
         url = get_modal_transcript_url()


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation


___

### **Description**
- Updated Whisper transcriber API to match Parakeet

- Added URL-based transcription endpoint

- Improved concurrency handling with modal.concurrent

- Added comprehensive API documentation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reflector_transcriber.py</strong><dd><code>Refactor transcriber API for compatibility with Parakeet</code>&nbsp; </dd></summary>
<hr>

server/gpu/modal_deployments/reflector_transcriber.py

<li>Updated API to accept bytes instead of string for audio_data<br> <li> Added URL-based transcription endpoint with timestamp offset support<br> <li> Replaced allow_concurrent_inputs with modal.concurrent decorator<br> <li> Added multi-file transcription support with batch processing


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/602/files#diff-1491a8e6983b5ff32567168b344e4d21845086faf478f29540a9d25d3b7457fc">+106/-21</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_gpu_modal_transcript.py</strong><dd><code>Update tests for Parakeet compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/tests/test_gpu_modal_transcript.py

- Added conditional test skipping for Parakeet-specific functionality


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/602/files#diff-2c8e07462087e1e9e6ddfa8e73825f74c59fcaed2dbcd9f44ac8842ff61f2c98">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api-transcription.md</strong><dd><code>Add detailed API documentation for transcription service</code>&nbsp; </dd></summary>
<hr>

server/docs/gpu/api-transcription.md

<li>Added comprehensive documentation for the transcription API<br> <li> Described endpoints, request/response formats, and authentication<br> <li> Included examples for both file upload and URL-based transcription<br> <li> Documented error handling and implementation details


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/602/files#diff-07f43c8e3c71b13e70647d17a41ae28f3f699bcb9d43fbda9b0614093fc03a24">+178/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>