### PR TITLE
fix: ignore player hotkeys for text inputs

### DIFF
--- a/www/app/(app)/transcripts/player.tsx
+++ b/www/app/(app)/transcripts/player.tsx
@@ -53,7 +53,7 @@ export default function Player(props: PlayerProps) {
     return () => {
       document.removeEventListener("keydown", keyHandler);
     };
-  });
+  }, [wavesurfer]);
 
   // Waveform setup
   useEffect(() => {

--- a/www/app/(app)/transcripts/player.tsx
+++ b/www/app/(app)/transcripts/player.tsx
@@ -33,15 +33,25 @@ export default function Player(props: PlayerProps) {
   const topicsRef = useRef(props.topics);
   const [firstRender, setFirstRender] = useState<boolean>(true);
 
-  const keyHandler = (e) => {
-    if (e.key == " ") {
+  const shouldIgnoreHotkeys = (target: EventTarget | null) => {
+    return (
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement
+    );
+  };
+
+  const keyHandler = (e: KeyboardEvent) => {
+    if (e.key === " ") {
+      if (e.repeat) return;
+      if (shouldIgnoreHotkeys(e.target)) return;
+      e.preventDefault();
       wavesurfer?.playPause();
     }
   };
   useEffect(() => {
-    document.addEventListener("keyup", keyHandler);
+    document.addEventListener("keydown", keyHandler);
     return () => {
-      document.removeEventListener("keyup", keyHandler);
+      document.removeEventListener("keydown", keyHandler);
     };
   });
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix spacebar hotkey in text inputs

- Prevent event propagation with preventDefault()

- Switch from keyup to keydown event

- Add check for repeated key presses


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>player.tsx</strong><dd><code>Improve keyboard event handling for player controls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

www/app/(app)/transcripts/player.tsx

<li>Added <code>shouldIgnoreHotkeys</code> function to detect text inputs<br> <li> Changed event listener from keyup to keydown<br> <li> Added prevention of default behavior with preventDefault()<br> <li> Added check to ignore repeated key presses


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/646/files#diff-6ad3702b209dea394a1050ba1a9328778fe9cce1711ad2560f0700d2e4038e13">+14/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>