### PR TITLE
fix: TypeError on not all arguments converted during string formatting in logger

### DIFF
--- a/server/reflector/worker/process.py
+++ b/server/reflector/worker/process.py
@@ -213,7 +213,6 @@ async def process_meetings():
                 should_deactivate = True
                 logger_.info(
                     "Meeting deactivated - scheduled time ended with no participants",
-                    meeting.id,
                 )
             else:
                 logger_.debug("Meeting not yet started, keep it")
@@ -224,8 +223,8 @@ async def process_meetings():
 
             processed_count += 1
 
-        except Exception as e:
-            logger_.error(f"Error processing meeting", exc_info=True)
+        except Exception:
+            logger_.error("Error processing meeting", exc_info=True)
         finally:
             try:
                 lock.release()
@@ -233,7 +232,7 @@ async def process_meetings():
                 pass  # Lock already released or expired
 
     logger.info(
-        f"Processed meetings finished",
+        "Processed meetings finished",
         processed_count=processed_count,
         skipped_count=skipped_count,
     )


### PR DESCRIPTION
### **User description**
Fix for error in production:

```
stacks-reflector-worker-1  | [2025-09-22 04:35:49,975: ERROR/ForkPoolWorker-1] reflector.worker.process.process_meetings[58220b7a-5471-4b71-aea2-bb6cf26f9c3b]: 2025-09-22 04:35:49 [error    ] Error processing meeting       meeting_id=110794554 room_name=/e9d376cd-8747-49a5-b16b-abe53bcc5613
stacks-reflector-worker-1  | ╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
stacks-reflector-worker-1  | │ /app/reflector/worker/process.py:214 in process_meetings                                         │
stacks-reflector-worker-1  | │                                                                                                  │
stacks-reflector-worker-1  | │   211 │   │   │   │   logger_.info("Meeting ended - all participants left")                      │
stacks-reflector-worker-1  | │   212 │   │   │   elif current_time > end_date:                                                  │
stacks-reflector-worker-1  | │   213 │   │   │   │   should_deactivate = True                                                   │
stacks-reflector-worker-1  | │ ❱ 214 │   │   │   │   logger_.info(                                                              │
stacks-reflector-worker-1  | │   215 │   │   │   │   │   "Meeting deactivated - scheduled time ended with no participants",     │
stacks-reflector-worker-1  | │   216 │   │   │   │   │   meeting.id,                                                            │
stacks-reflector-worker-1  | │   217 │   │   │   │   )                                                                          │
stacks-reflector-worker-1  | │                                                                                                  │
stacks-reflector-worker-1  | │ ╭─────────────────────────────────────────── locals ───────────────────────────────────────────╮ │
stacks-reflector-worker-1  | │ │        current_time = datetime.datetime(2025, 9, 22, 4, 35, 47, 580293,                      │ │
stacks-reflector-worker-1  | │ │                       tzinfo=datetime.timezone.utc)                                          │ │
stacks-reflector-worker-1  | │ │                   e = TypeError('not all arguments converted during string formatting')      │ │
stacks-reflector-worker-1  | │ │            end_date = datetime.datetime(2025, 9, 20, 6, 21, 59, 454000,                      │ │
stacks-reflector-worker-1  | │ │                       tzinfo=datetime.timezone.utc)                                          │ │
stacks-reflector-worker-1  | │ │ has_active_sessions = []                                                                     │ │
stacks-reflector-worker-1  | │ │    has_had_sessions = False                                                                  │ │
stacks-reflector-worker-1  | │ │                lock = <redis.lock.Lock object at 0xffff82f37050>                             │ │
stacks-reflector-worker-1  | │ │            lock_key = 'meeting_process_lock:110794554'                                       │ │
stacks-reflector-worker-1  | │ │             logger_ = <BoundLoggerFilteringAtNotset(context={'meeting_id': '110794554',      │ │
stacks-reflector-worker-1  | │ │                       'room_name': '/e9d376cd-8747-49a5-b16b-abe53bcc5613'},                 │ │
stacks-reflector-worker-1  | │ │                       processors=[<function merge_contextvars at 0xffffbb27cea0>, <function  │ │
stacks-reflector-worker-1  | │ │                       add_log_level at 0xffffbb27f1a0>,                                      │ │
stacks-reflector-worker-1  | │ │                       <structlog.processors.StackInfoRenderer object at 0xffffbadf85b0>,     │ │
stacks-reflector-worker-1  | │ │                       <function set_exc_info at 0xffffbadd9f80>,                             │ │
stacks-reflector-worker-1  | │ │                       <structlog.processors.TimeStamper object at 0xffffbada2300>,           │ │
stacks-reflector-worker-1  | │ │                       <structlog.dev.ConsoleRenderer object at 0xffffbadfb380>])>            │ │
stacks-reflector-worker-1  | │ │             meeting = <databases.backends.postgres.Record object at 0xffff82f58950>          │ │
stacks-reflector-worker-1  | │ │            meetings = [                                                                      │ │
stacks-reflector-worker-1  | │ │                       │   <databases.backends.postgres.Record object at 0xffff82f5b650>,     │ │
stacks-reflector-worker-1  | │ │                       │   <databases.backends.postgres.Record object at 0xffff82f598b0>,     │ │
stacks-reflector-worker-1  | │ │                       │   <databases.backends.postgres.Record object at 0xffff82f58530>,     │ │
stacks-reflector-worker-1  | │ │                       │   <databases.backends.postgres.Record object at 0xffff82f58950>      │ │
stacks-reflector-worker-1  | │ │                       ]                                                                      │ │
stacks-reflector-worker-1  | │ │     processed_count = 0                                                                      │ │
stacks-reflector-worker-1  | │ │        redis_client = <redis.client.Redis(<redis.connection.ConnectionPool(<redis.connectio… │ │
stacks-reflector-worker-1  | │ │            response = {'results': [], 'cursor': None}                                        │ │
stacks-reflector-worker-1  | │ │       room_sessions = []                                                                     │ │
stacks-reflector-worker-1  | │ │   should_deactivate = True                                                                   │ │
stacks-reflector-worker-1  | │ │       skipped_count = 0                                                                      │ │
stacks-reflector-worker-1  | │ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
stacks-reflector-worker-1  | │                                                                                                  │
stacks-reflector-worker-1  | │ /app/.venv/lib/python3.12/site-packages/structlog/_native.py:146 in meth                         │
stacks-reflector-worker-1  | │                                                                                                  │
stacks-reflector-worker-1  | │   143 │   │   │   if not args:                                                                   │
stacks-reflector-worker-1  | │   144 │   │   │   │   return self._proxy_to_logger(name, event, **kw)                            │
stacks-reflector-worker-1  | │   145 │   │   │                                                                                  │
stacks-reflector-worker-1  | │ ❱ 146 │   │   │   return self._proxy_to_logger(name, event % args, **kw)                         │
stacks-reflector-worker-1  | │   147 │   │                                                                                      │
stacks-reflector-worker-1  | │   148 │   │   async def ameth(self: Any, event: str, *args: Any, **kw: Any) -> Any:              │
stacks-reflector-worker-1  | │   149 │   │   │   """                                                                            │
stacks-reflector-worker-1  | │                                                                                                  │
stacks-reflector-worker-1  | │ ╭─────────────────────────────────────────── locals ───────────────────────────────────────────╮ │
stacks-reflector-worker-1  | │ │  args = ('110794554',)                                                                       │ │
stacks-reflector-worker-1  | │ │ event = 'Meeting deactivated - scheduled time ended with no participants'                    │ │
stacks-reflector-worker-1  | │ │    kw = {}                                                                                   │ │
stacks-reflector-worker-1  | │ │  name = 'info'                                                                               │ │
stacks-reflector-worker-1  | │ │  self = <BoundLoggerFilteringAtNotset(context={'meeting_id': '110794554', 'room_name':       │ │
stacks-reflector-worker-1  | │ │         '/e9d376cd-8747-49a5-b16b-abe53bcc5613'}, processors=[<function merge_contextvars at │ │
stacks-reflector-worker-1  | │ │         0xffffbb27cea0>, <function add_log_level at 0xffffbb27f1a0>,                         │ │
stacks-reflector-worker-1  | │ │         <structlog.processors.StackInfoRenderer object at 0xffffbadf85b0>, <function         │ │
stacks-reflector-worker-1  | │ │         set_exc_info at 0xffffbadd9f80>, <structlog.processors.TimeStamper object at         │ │
stacks-reflector-worker-1  | │ │         0xffffbada2300>, <structlog.dev.ConsoleRenderer object at 0xffffbadfb380>])>         │ │
stacks-reflector-worker-1  | │ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
stacks-reflector-worker-1  | ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
stacks-reflector-worker-1  | TypeError: not all arguments con
```


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed TypeError in logger string formatting

- Removed unnecessary f-strings

- Removed extra parameter in logger.info call


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>process.py</strong><dd><code>Fix string formatting issues in logger calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/reflector/worker/process.py

<li>Removed extra parameter <code>meeting.id</code> from logger.info call<br> <li> Removed f-string prefix from log messages that don't use string <br>interpolation<br> <li> Fixed error logging format to prevent TypeError


</details>


  </td>
  <td><a href="https://github.com/Monadical-SAS/reflector/pull/667/files#diff-68019eddc4079e7b8930374204c5fe955c3ee56cd7044ea12014af50cbc31771">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>